### PR TITLE
Remove personal blogs from Planet news

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -21,8 +21,8 @@ output_theme = classic_fancy
 [https://buddypress.org/feed/]
 name = BuddyPress
 
-[https://dothewoo.io/feed/]
-name = Do The Woo Community
+[https://openchannels.fm/feed/]
+name = OpenChannels.fm
 
 [https://gutenbergtimes.com/feed/]
 name = Gutenberg Times

--- a/config.ini
+++ b/config.ini
@@ -24,9 +24,6 @@ name = BuddyPress
 [https://dothewoo.io/feed/]
 name = Do The Woo Community
 
-[https://fair.pm/feed/]
-name = FAIR
-
 [https://gutenbergtimes.com/feed/]
 name = Gutenberg Times
 

--- a/config.ini
+++ b/config.ini
@@ -18,48 +18,20 @@ date_format = %B %d, %Y %I:%M %p %Z
 new_date_format = %B %d, %Y
 output_theme = classic_fancy
 
-
-[https://ozz.blog/feed/]
-name = Andrew
-
-[https://nacin.com/tag/wordpress/feed/planet/]
-name = Andrew Nacin
-
-[https://andyskelton.com/tag/wordpress/feed/]
-name = Andy Skelton
-
 [https://buddypress.org/feed/]
 name = BuddyPress
 
 [https://dothewoo.io/feed/]
 name = Do The Woo Community
 
-[https://odd.blog/category/wordpress/feed/]
-name = Donncha
-
-[https://dougal.gunters.org/blog/tag/wordpress/feed/]
-name = Dougal Campbell
-
-[https://pento.net/category/wordpress/feed/]
-name = Gary
+[https://fair.pm/feed/]
+name = FAIR
 
 [https://gutenbergtimes.com/feed/]
 name = Gutenberg Times
 
 [https://heropress.com/feed/]
 name = HeroPress
-
-[https://markjaquith.wordpress.com/feed/]
-name = Mark Jaquith
-
-[https://ma.tt/feed/?cat=-49]
-name = Matt
-
-[https://journalized.zed1.com/category/blog/wordpress/feed/]
-name = Mike Little
-
-[https://westi.wordpress.com/feed/]
-name = Peter Westwood
 
 [https://poststatus.com/category/planet/feed]
 name = Post Status


### PR DESCRIPTION
This PR removes personal blogs from the FAIR planet news (and adds FAIR's feed (assuming `https://fair.pm/feed/` will map to news (as opposed to `fair.pm/news/feed/`)).