### PR TITLE
updating config list of feed sources

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -19,26 +19,14 @@ new_date_format = %B %d, %Y
 output_theme = classic_fancy
 
 
-[https://ozz.blog/feed/]
-name = Andrew
-
-[https://nacin.com/tag/wordpress/feed/planet/]
-name = Andrew Nacin
-
-[https://andyskelton.com/tag/wordpress/feed/]
-name = Andy Skelton
-
 [https://buddypress.org/feed/]
 name = BuddyPress
 
-[https://dothewoo.io/feed/]
-name = Do The Woo Community
+[https://openchannels.fm/feed]
+name = OpenChannels.fm
 
 [https://odd.blog/category/wordpress/feed/]
 name = Donncha
-
-[https://dougal.gunters.org/blog/tag/wordpress/feed/]
-name = Dougal Campbell
 
 [https://pento.net/category/wordpress/feed/]
 name = Gary
@@ -49,17 +37,8 @@ name = Gutenberg Times
 [https://heropress.com/feed/]
 name = HeroPress
 
-[https://markjaquith.wordpress.com/feed/]
-name = Mark Jaquith
-
 [https://ma.tt/feed/?cat=-49]
 name = Matt
-
-[https://journalized.zed1.com/category/blog/wordpress/feed/]
-name = Mike Little
-
-[https://westi.wordpress.com/feed/]
-name = Peter Westwood
 
 [https://poststatus.com/category/planet/feed]
 name = Post Status


### PR DESCRIPTION
this PR has 7 removals and 1 update.

**Changes**
"Doo The Woo" has been rebranded as Open Channels FM, this change reflects that.

**Removals**
the following sites have not been updated in over 5 years, with some more than 10 years.

- https://ozz.blog/feed/
- https://nacin.com/tag/wordpress/feed/planet/
- https://andyskelton.com/tag/wordpress/feed/
- https://dougal.gunters.org/blog/tag/wordpress/feed/
- https://markjaquith.wordpress.com/feed/
- https://journalized.zed1.com/category/blog/wordpress/feed/
- https://westi.wordpress.com/feed/